### PR TITLE
Verify the identifier after the player is connected in the server

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -10,3 +10,5 @@ Config.DiscordColor = '6749952'
 Config.DiscordUserName = 'BulgaR Dconnect Blocker'
 Config.DiscordTitle = 'Attempting to Double Enter the Server'
 Config.EnableDiscordLogs = false
+Config.PlayerLoaded = "esx:playerLoaded" -- handler when the player is loaded in the server
+Config.PlayerDropped = "playerDropped"

--- a/server.lua
+++ b/server.lua
@@ -113,3 +113,28 @@ function IsIdtypeInUse(idtype, vmethod)
     end
     return false
 end
+
+local connectedPlayers = {}
+
+AddEventHandler(Config.PlayerLoaded, function(source)
+	local id
+	connectedPlayers[source] = {}
+	for k,v in ipairs(GetPlayerIdentifiers(source))do
+		if string.sub(v, 1, string.len(Config.VerificationMethod..":")) == Config.VerificationMethod..":" then
+			id = v
+			break
+		end
+	end
+	for s, t in pairs(connectedPlayers) do
+		if t.identifier == id then
+			DropPlayer(source, "Already connected.")
+			connectedPlayers[source] = nil
+		else
+			connectedPlayers[source].identifier = id
+		end
+	end
+end)
+
+AddEventHandler(Config.PlayerDropped, function(reason)
+	connectedPlayers[source] = nil
+end)


### PR DESCRIPTION
If the players press connect at the same time, deferrals can't prevent players from joining at the same time with the same identifier, but if we make a verification after the player is loaded, it will prevent the player from connecting.